### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - run: pytest -m "not integration" -v
+        env:
+          SECRET_KEY: ci-test-secret-key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 os.environ.setdefault('AUTH_TOKEN', 'test_auth_token')
+os.environ.setdefault('ADMIN_SECRET', 'JBSWY3DPEHPK3PXP')
 
 from api.index import app
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,8 @@ import uuid
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from api import admin_routes
 from api.models import Prompt
 from tests.helpers import TEST_MARKER_TAG, auth_headers, build_prompt_payload

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,6 +1,9 @@
+import pytest
+
 from tests.helpers import auth_headers
 
 
+@pytest.mark.unit
 def test_locale_endpoint_sets_cookie(client):
     response = client.get('/locale/zh_Hans')
     assert response.status_code == 302
@@ -8,23 +11,27 @@ def test_locale_endpoint_sets_cookie(client):
     assert 'locale=zh_Hans' in set_cookie
 
 
+@pytest.mark.unit
 def test_locale_endpoint_redirects_back(client):
     response = client.get('/locale/zh_Hans', headers={'Referer': 'http://localhost/admin/prompts'})
     assert response.status_code == 302
     assert response.headers['Location'] == 'http://localhost/admin/prompts'
 
 
+@pytest.mark.unit
 def test_locale_endpoint_invalid_returns_404(client):
     response = client.get('/locale/fr')
     assert response.status_code == 404
 
 
+@pytest.mark.unit
 def test_locale_endpoint_rejects_external_referrer(client):
     response = client.get('/locale/zh_Hans', headers={'Referer': 'https://evil.com/phishing'})
     assert response.status_code == 302
     assert response.headers['Location'] == '/'
 
 
+@pytest.mark.unit
 def test_login_page_renders_chinese_with_cookie(client):
     client.set_cookie('locale', 'zh_Hans')
     response = client.get('/admin/login')
@@ -34,6 +41,7 @@ def test_login_page_renders_chinese_with_cookie(client):
     assert 'Welcome Back' not in page
 
 
+@pytest.mark.unit
 def test_login_page_renders_english_by_default(client):
     response = client.get('/admin/login')
     assert response.status_code == 200
@@ -41,6 +49,7 @@ def test_login_page_renders_english_by_default(client):
     assert 'Welcome Back' in page
 
 
+@pytest.mark.unit
 def test_html_lang_attribute_reflects_locale(client):
     client.set_cookie('locale', 'zh_Hans')
     response = client.get('/admin/login')
@@ -48,12 +57,14 @@ def test_html_lang_attribute_reflects_locale(client):
     assert 'lang="zh_Hans"' in page
 
 
+@pytest.mark.unit
 def test_html_lang_attribute_default_en(client):
     response = client.get('/admin/login')
     page = response.get_data(as_text=True)
     assert 'lang="en"' in page
 
 
+@pytest.mark.unit
 def test_api_unauthorized_stays_english_regardless_of_locale(client):
     client.set_cookie('locale', 'zh_Hans')
     response = client.get('/api/prompts')

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,6 +4,7 @@ from api.admin_routes import TEMPLATE_VAR_PATTERN, render_prompt_preview
 from api.config import DEFAULT_AUTH_TOKEN_PLACEHOLDER, get_auth_token
 
 
+@pytest.mark.unit
 class TestTemplateVarPattern:
     def test_matches_simple_variable(self):
         match = TEMPLATE_VAR_PATTERN.search('Hello {{name}}')
@@ -44,6 +45,7 @@ class TestTemplateVarPattern:
         assert 'name' in matches
 
 
+@pytest.mark.unit
 class TestRenderPromptPreview:
     def test_simple_replacement(self):
         result = render_prompt_preview('Hello {{name}}', {'name': 'World'})
@@ -87,6 +89,7 @@ class TestRenderPromptPreview:
         assert result == 'Bob'
 
 
+@pytest.mark.unit
 class TestGetAuthToken:
     def test_returns_valid_token(self, monkeypatch):
         monkeypatch.setenv('AUTH_TOKEN', 'my-valid-token')


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with unit test CI pipeline
- Add `@pytest.mark.unit` to test_unit.py (3 classes) and test_i18n.py (9 functions)
- Add module-level `pytestmark = pytest.mark.integration` to test_api.py
- CI runs `pytest -m "not integration"` — 33 tests, no MongoDB required

## Test plan
- [x] `pytest -m "not integration"` passes locally (33 passed, 24 deselected)
- [ ] CI workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)